### PR TITLE
World to local for odometry positioning

### DIFF
--- a/public/config.schema.json
+++ b/public/config.schema.json
@@ -183,6 +183,15 @@
                         "Odometry"
                       ]
                     },
+                    "localizationWorldToLocal": {
+                      "type": "boolean",
+                      "default": true,
+                      "$formant.visible.when": [
+                        "positioningType",
+                        "=",
+                        "Odometry"
+                      ]
+                    },
                     "localizationRealtimeStream": {
                       "type": "string",
                       "$formant.visible.when": [
@@ -305,6 +314,15 @@
                         "Odometry"
                       ]
                     },
+                    "localizationWorldToLocal": {
+                      "type": "boolean",
+                      "default": true,
+                      "$formant.visible.when": [
+                        "positioningType",
+                        "=",
+                        "Odometry"
+                      ]
+                    },
                     "localizationRealtimeStream": {
                       "type": "string",
                       "$formant.visible.when": [
@@ -417,6 +435,15 @@
                         "Odometry"
                       ]
                     },
+                    "localizationWorldToLocal": {
+                      "type": "boolean",
+                      "default": true,
+                      "$formant.visible.when": [
+                        "positioningType",
+                        "=",
+                        "Odometry"
+                      ]
+                    },
                     "localizationRealtimeStream": {
                       "type": "string",
                       "$formant.visible.when": [
@@ -502,6 +529,11 @@
               "localizationStream": {
                 "type": "string",
                 "$formant.streams.byType": "localization",
+                "$formant.visible.when": ["positioningType", "=", "Odometry"]
+              },
+              "localizationWorldToLocal": {
+                "type": "boolean",
+                "default": true,
                 "$formant.visible.when": ["positioningType", "=", "Odometry"]
               },
               "localizationRealtimeStream": {

--- a/src/Demo.tsx
+++ b/src/Demo.tsx
@@ -47,7 +47,7 @@ export function Demo() {
             name="Map"
           />
           <DataVisualizationLayer
-            positioning={PositioningBuilder.localization("eko.loc")}
+            positioning={PositioningBuilder.odometry("eko.loc")}
             name="Ekobot"
           >
             <MarkerLayer

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export type Viewer3DConfiguarationPositioning = {
   gpsStream?: string;
   localizationStream?: string;
   localizationRealtimeStream?: string;
+  localizationWorldToLocal?: boolean;
   transformTreeStream?: string;
   transformTreeEndPoint?: string;
 };
@@ -97,9 +98,7 @@ export function parsePositioning(
         lat: positioning.relativeLatitude || 0,
       });
     case "Odometry":
-      return PositioningBuilder.localization(
-        positioning.localizationStream || ""
-      );
+      return PositioningBuilder.odometry(positioning.localizationStream || "");
     case "Transform Tree":
       return PositioningBuilder.tranformTree(
         positioning.transformTreeStream || "",

--- a/src/layers/common/Positioning.ts
+++ b/src/layers/common/Positioning.ts
@@ -1,6 +1,8 @@
+import { StreamType } from "@formant/universe-core";
+
 export type Positioning =
   | {
-      type: "fixed";
+      type: "cartesian";
       x: number;
       y: number;
       z: number;
@@ -13,7 +15,9 @@ export type Positioning =
   | {
       type: "odometry";
       stream?: string;
+      streamType: StreamType;
       rtcStream?: string;
+      useWorldToLocalTransform?: boolean;
     }
   | {
       type: "gps";

--- a/src/layers/utils/PositioningBuilder.ts
+++ b/src/layers/utils/PositioningBuilder.ts
@@ -1,12 +1,21 @@
+import { StreamType } from "@formant/universe-core";
 import { Positioning } from "../common/Positioning";
 
 export class PositioningBuilder {
   static fixed(x: number, y: number, z: number): Positioning {
-    return { type: "fixed", x, y, z };
+    return { type: "cartesian", x, y, z };
   }
 
-  static localization(stream: string): Positioning {
-    return { type: "odometry", stream };
+  static odometry(
+    stream: string,
+    localizationWorldToLocal?: boolean
+  ): Positioning {
+    return {
+      type: "odometry",
+      stream,
+      streamType: "localization",
+      useWorldToLocalTransform: localizationWorldToLocal,
+    };
   }
 
   static gps(

--- a/src/layers/utils/transformMatrix.ts
+++ b/src/layers/utils/transformMatrix.ts
@@ -1,0 +1,14 @@
+import { ITransform, IVector3, IQuaternion } from "@formant/universe-core";
+import { Matrix4, Vector3, Quaternion } from "three";
+
+export function transformMatrix({
+  translation,
+  rotation,
+}: ITransform): Matrix4 {
+  const vector = ({ x, y, z }: IVector3) => new Vector3(x, y, z);
+  const quaternion = ({ x, y, z, w }: IQuaternion) =>
+    new Quaternion(x, y, z, w);
+  return new Matrix4()
+    .multiply(new Matrix4().setPosition(vector(translation)))
+    .multiply(new Matrix4().makeRotationFromQuaternion(quaternion(rotation)));
+}


### PR DESCRIPTION
Adding support for world to local for odometry positioning.

Steps to test:

Find a device with localization with odometry and uses world to localization.

Add a circle marker layer and positioning it.

<img width="469" alt="Screen Shot 2023-02-16 at 5 45 20 PM" src="https://user-images.githubusercontent.com/66638393/219528359-e23c4847-d0b0-4369-bb45-9f3cab66247d.png">

<img width="586" alt="Screen Shot 2023-02-16 at 5 46 31 PM" src="https://user-images.githubusercontent.com/66638393/219528508-0a79658d-29ee-4fc3-8e26-6d8577fa5ee0.png">
