### PR TITLE
Using custom bounds to reframe camera

### DIFF
--- a/src/Demo.tsx
+++ b/src/Demo.tsx
@@ -78,7 +78,7 @@ export function Demo() {
               )}
               name="Path"
             />
-            <RouteMakerLayer size={200} name="Route Builder" />
+            {/* <RouteMakerLayer size={200} name="Route Builder" /> */}
           </DataVisualizationLayer>
         </LayerContext.Provider>
       </Universe>

--- a/src/Demo.tsx
+++ b/src/Demo.tsx
@@ -30,6 +30,15 @@ export function Demo() {
           positioning={PositioningBuilder.fixed(0, 0.1, 0)}
           name="Ground"
         />
+        <MapLayer
+          mapType="Satellite"
+          positioning={PositioningBuilder.fixed(0, 0, -3)}
+          name="Map"
+          size={500}
+          mapBoxKey=""
+          longitude={-122.6765}
+          latitude={45.5231}
+        />
         <LayerContext.Provider
           value={{
             deviceId: "ekobot_device",

--- a/src/layers/GroundLayer.tsx
+++ b/src/layers/GroundLayer.tsx
@@ -27,13 +27,16 @@ export function GroundLayer(props: IGroundLayer) {
   }, []);
 
   return (
-    <DataVisualizationLayer {...props} iconUrl="icons/3d_object.svg">
-      <Axis />
-      <primitive object={axisLayers} />
-      {range(0, 100).map((i) => (
-        <SilverCircle key={i} width={i} />
-      ))}
-      {children}
-    </DataVisualizationLayer>
+    <group name="axis">
+      <DataVisualizationLayer {...props} iconUrl="icons/3d_object.svg">
+        <Axis />
+        <primitive object={axisLayers} />
+        {range(0, 100).map((i) => (
+          <SilverCircle key={i} width={i} />
+        ))}
+        {children}
+      </DataVisualizationLayer>
+    </group>
+
   );
 }

--- a/src/layers/MapLayer.tsx
+++ b/src/layers/MapLayer.tsx
@@ -6,13 +6,14 @@ import {
   UniverseTelemetrySource,
 } from "@formant/universe-core";
 import { computeDestinationPoint } from "geolib";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useLayoutEffect, useState } from "react";
 import { Texture } from "three";
 import { LayerContext } from "./common/LayerContext";
 import { DataVisualizationLayer } from "./DataVisualizationLayer";
 import { IUniverseLayerProps } from "./types";
 import { loadTexture } from "./utils/loadTexture";
 import { UniverseDataContext } from "./common/UniverseDataContext";
+import { useBounds } from "./common/CustomBounds";
 
 const URL_SCOPED_TOKEN =
   "pk.eyJ1IjoiYWJyYWhhbS1mb3JtYW50IiwiYSI6ImNrOWVuazlhbTAwdDYza203b2tybGZmNDMifQ.Ro6iNGYgvpDO4i6dcxeDGg";
@@ -39,6 +40,7 @@ export function MapLayer(props: IMapLayer) {
   const [currentLocation, setCurrentLocation] = useState<
     [number, number] | undefined
   >(undefined);
+  const bounds = useBounds();
 
   useEffect(() => {
     (async () => {
@@ -123,7 +125,15 @@ export function MapLayer(props: IMapLayer) {
       }
     })();
   }, []);
+
   const mapReady = mapTexture !== undefined;
+
+  useLayoutEffect(() => {
+    if (mapReady) {
+      bounds.refresh().clip().fit();
+    }
+  }, [mapReady])
+
   return (
     <DataVisualizationLayer {...props} iconUrl="icons/map.svg">
       {mapReady && (

--- a/src/layers/MarkerLayer.tsx
+++ b/src/layers/MarkerLayer.tsx
@@ -4,9 +4,10 @@ import { useFrame, extend } from "@react-three/fiber";
 import { DataVisualizationLayer } from "./DataVisualizationLayer";
 import { IUniverseLayerProps } from "./types";
 import { MarkerMaterial } from "./utils/MarkerMaterial";
+import { LayerType } from "./common/LayerTypes";
 extend({ MarkerMaterial });
 
-interface IMarkerLayerProps extends IUniverseLayerProps {}
+interface IMarkerLayerProps extends IUniverseLayerProps { }
 
 export function MarkerLayer(props: IMarkerLayerProps) {
   const { children } = props;
@@ -47,7 +48,7 @@ export function MarkerLayer(props: IMarkerLayerProps) {
   });
 
   return (
-    <DataVisualizationLayer {...props} iconUrl="icons/3d_object.svg">
+    <DataVisualizationLayer {...props} type={LayerType.TRACKABLE} iconUrl="icons/3d_object.svg">
       <group>
         <mesh ref={arrowRef} name="arrow" rotation={[0, 0, -Math.PI / 2]}>
           <shapeGeometry args={[arrowShape]} />

--- a/src/layers/OccupancyGridLayer.tsx
+++ b/src/layers/OccupancyGridLayer.tsx
@@ -18,6 +18,7 @@ import {
   PlaneGeometry,
 } from "three";
 import { FormantColors } from "./utils/FormantColors";
+import { useBounds } from "./common/CustomBounds";
 
 interface IPointOccupancyGridProps extends IUniverseLayerProps {
   dataSource?: UniverseTelemetrySource;
@@ -38,8 +39,13 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
   const { dataSource } = props;
   const universeData = useContext(UniverseDataContext);
   const layerData = useContext(LayerContext);
+  const bounds = useBounds();
 
   const [obj, setObj] = useState(new Mesh());
+
+  const gridMat = new MeshBasicMaterial({ transparent: true });
+  const mesh = new Mesh(new PlaneGeometry(), gridMat);
+  mesh.visible = false;
 
   useEffect(() => {
     if (!layerData || !dataSource) return;
@@ -47,9 +53,6 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
     const { deviceId } = layerData;
     dataSource.streamType = "localization";
 
-    const gridMat = new MeshBasicMaterial({ transparent: true });
-    const mesh = new Mesh(new PlaneGeometry(), gridMat);
-    mesh.visible = false;
     setObj(mesh);
 
     const unsubscribe = universeData.subscribeToGridMap(
@@ -110,7 +113,11 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
         gridMat.map = texture;
         gridMat.needsUpdate = true;
 
-        mesh.visible = true;
+        if (!mesh.visible) {
+          mesh.visible = true;
+          bounds.refresh().clip().fit();
+        }
+
       }
     );
 

--- a/src/layers/common/ControlsContext.tsx
+++ b/src/layers/common/ControlsContext.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+
+
+export const ControlsContext = React.createContext<any>(
+    null
+);

--- a/src/layers/common/CustomBounds.tsx
+++ b/src/layers/common/CustomBounds.tsx
@@ -147,8 +147,11 @@ export function Bounds({ children, damping = 6, fit, clip, observe, margin = 1.2
         return this
       },
       clip() {
-        const { distance } = getSize()
-        if (controls) controls.maxDistance = distance * 10;
+        const { distance } = getSize();
+        if (controls) {
+          controls.maxDistance = distance * 10;
+          controls.update();
+        }
         camera.near = distance / 100
         camera.far = distance * 100
         camera.updateProjectionMatrix()
@@ -176,15 +179,16 @@ export function Bounds({ children, damping = 6, fit, clip, observe, margin = 1.2
       },
       fit() {
         if (!current.animating) {
-          current.camera.copy(camera.position)
+          current.camera.copy(new THREE.Vector3(0, 0, 50))
         }
         if (controls) current.focus.copy(controls.target)
 
-        const { center, distance } = getSize()
-        const direction = camera.getWorldDirection(new THREE.Vector3(0, 0, 0));
 
-        goal.camera.copy(center).setZ(Math.max(distance, 15)).sub(direction);
-        goal.focus.copy(center)
+        const { center, distance } = getSize()
+        const direction = camera.getWorldDirection(new THREE.Vector3()).round(); // direction is the direction the camera is facing
+
+        goal.camera.copy(center).sub(direction).setZ(Math.max(distance, 15));
+        goal.focus.copy(center).sub(direction).setZ(0);
 
         if (isOrthographic(camera)) {
           current.zoom = camera.zoom
@@ -266,7 +270,6 @@ export function Bounds({ children, damping = 6, fit, clip, observe, margin = 1.2
         camera.zoom = current.zoom
         camera.updateProjectionMatrix()
       }
-
       if (!controls) {
         camera.lookAt(current.focus)
       } else {

--- a/src/layers/common/CustomBounds.tsx
+++ b/src/layers/common/CustomBounds.tsx
@@ -1,0 +1,291 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { useFrame, useThree } from '@react-three/fiber'
+
+export type SizeProps = {
+  box: THREE.Box3
+  size: THREE.Vector3
+  center: THREE.Vector3
+  distance: number
+}
+
+export type BoundsApi = {
+  getSize: () => SizeProps
+  refresh(object?: THREE.Object3D | THREE.Box3): any
+  clip(): any
+  fit(): any
+  to: ({ position, target }: { position: [number, number, number]; target?: [number, number, number] }) => any
+}
+
+export type BoundsProps = JSX.IntrinsicElements['group'] & {
+  damping?: number
+  fit?: boolean
+  clip?: boolean
+  observe?: boolean
+  margin?: number
+  eps?: number
+  onFit?: (data: SizeProps) => void
+}
+
+type ControlsProto = {
+  update(): void
+  target: THREE.Vector3
+  maxDistance: number
+  addEventListener: (event: string, callback: (event: any) => void) => void
+  removeEventListener: (event: string, callback: (event: any) => void) => void
+}
+
+const isOrthographic = (def: THREE.Camera): def is THREE.OrthographicCamera =>
+  def && (def as THREE.OrthographicCamera).isOrthographicCamera
+const isBox3 = (def: any): def is THREE.Box3 => def && (def as THREE.Box3).isBox3
+
+const context = React.createContext<BoundsApi>(null!)
+export function Bounds({ children, damping = 6, fit, clip, observe, margin = 1.2, eps = 0.01, onFit }: BoundsProps) {
+  const ref = React.useRef<THREE.Group>(null!)
+  const { camera, invalidate, size, controls: controlsImpl } = useThree()
+  const controls = controlsImpl as unknown as ControlsProto
+
+  const onFitRef = React.useRef<((data: SizeProps) => void) | undefined>(onFit)
+  onFitRef.current = onFit
+
+  function equals(a: THREE.Vector3, b: THREE.Vector3) {
+    return Math.abs(a.x - b.x) < eps && Math.abs(a.y - b.y) < eps && Math.abs(a.z - b.z) < eps
+  }
+
+  function damp(v: THREE.Vector3, t: THREE.Vector3, lambda: number, delta: number) {
+    v.x = THREE.MathUtils.damp(v.x, t.x, lambda, delta)
+    v.y = THREE.MathUtils.damp(v.y, t.y, lambda, delta)
+    v.z = THREE.MathUtils.damp(v.z, t.z, lambda, delta)
+  }
+
+  const [current] = React.useState(() => ({
+    animating: false,
+    focus: new THREE.Vector3(),
+    camera: new THREE.Vector3(),
+    zoom: 1,
+  }))
+  const [goal] = React.useState(() => ({ focus: new THREE.Vector3(), camera: new THREE.Vector3(), zoom: 1 }))
+
+  const [box] = React.useState(() => new THREE.Box3())
+  const api: BoundsApi = React.useMemo(() => {
+    function getSize() {
+      const size = box.getSize(new THREE.Vector3())
+      const center = box.getCenter(new THREE.Vector3())
+      const maxSize = Math.max(size.x, size.y, size.z)
+      const fitHeightDistance = isOrthographic(camera)
+        ? maxSize * 4
+        : maxSize * margin / (2 * Math.tan((Math.PI * camera.fov) / 180))
+      const fitWidthDistance = isOrthographic(camera) ? maxSize * 4 : fitHeightDistance / camera.aspect
+      const distance = Math.max(fitHeightDistance, fitWidthDistance) * margin;
+      return { box, size, center, distance }
+    }
+
+    function isDescendantOfAxis(object: THREE.Object3D) {
+      let parent = object.parent;
+      while (parent !== null) {
+        if (parent.name === "axis") {
+          return true;
+        }
+        parent = parent.parent;
+      }
+      return false;
+    }
+
+    function expandBoxByObjectWithPosition(box: THREE.Box3, object: THREE.Mesh) {
+      const position = new THREE.Vector3();
+      position.setFromMatrixPosition(object.matrixWorld);
+      box.expandByPoint(position);
+      if (object.geometry) {
+        object.geometry.computeBoundingBox();
+        if (object.geometry.boundingBox === null) return; // is that even possible?
+        const geometryBoundingBox = object.geometry.boundingBox.clone();
+        geometryBoundingBox.applyMatrix4(object.matrixWorld);
+        box.union(geometryBoundingBox);
+      }
+    }
+
+    return {
+      getSize,
+      refresh(object?: THREE.Object3D | THREE.Box3) {
+        if (isBox3(object)) box.copy(object)
+        else {
+          const target = object || ref.current
+          target.updateWorldMatrix(true, true)
+          box.expandByObject(target);
+          if (object === undefined) {
+            const targetGroup = target.children[0]; // target is a group containing everything, target.children[0] is the actual target
+            targetGroup.updateWorldMatrix(true, true);
+            const tempBox = new THREE.Box3();
+            // traverse all children except axis and targetGroup
+            targetGroup.traverse((child: any) => {
+              if (child.name !== 'axis' && !isDescendantOfAxis(child) && child.uuid !== targetGroup.uuid && child.isMesh) {
+                const childBox = new THREE.Box3();
+                childBox.setFromObject(child);
+                expandBoxByObjectWithPosition(tempBox, child);
+              }
+            });
+            box.copy(tempBox);
+          }
+        }
+        if (box.isEmpty()) {
+          const max = camera.position.length() || 10
+          box.setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3(max, max, max))
+        }
+
+        if (controls?.constructor.name === 'OrthographicTrackballControls') {
+          // Put camera on a sphere along which it should move
+          const { distance } = getSize()
+          const direction = camera.position.clone().sub(controls.target).normalize().multiplyScalar(distance)
+          const newPos = controls.target.clone().add(direction)
+          camera.position.copy(newPos)
+        }
+
+        return this
+      },
+      clip() {
+        const { distance } = getSize()
+        if (controls) controls.maxDistance = distance * margin;
+        camera.near = distance / 100
+        camera.far = distance * 100
+        camera.updateProjectionMatrix()
+        if (controls) controls.update()
+        invalidate()
+        return this
+      },
+      to({ position, target }: { position: [number, number, number]; target?: [number, number, number] }) {
+        current.camera.copy(camera.position)
+        const { center } = getSize()
+        goal.camera.set(...position)
+
+        if (target) {
+          goal.focus.set(...target)
+        } else {
+          goal.focus.copy(center)
+        }
+
+        if (damping) {
+          current.animating = true
+        } else {
+          camera.position.set(...position)
+        }
+        return this
+      },
+      fit() {
+        if (!current.animating) {
+          current.camera.copy(camera.position)
+        }
+        if (controls) current.focus.copy(controls.target)
+
+        const { center, distance } = getSize()
+        const direction = camera.getWorldDirection(new THREE.Vector3(0, 0, 0));
+
+        goal.camera.copy(center).setZ(Math.max(distance, 15)).sub(direction);
+        goal.focus.copy(center)
+
+        if (isOrthographic(camera)) {
+          current.zoom = camera.zoom
+
+          let maxHeight = 0,
+            maxWidth = 0
+          const vertices = [
+            new THREE.Vector3(box.min.x, box.min.y, box.min.z),
+            new THREE.Vector3(box.min.x, box.max.y, box.min.z),
+            new THREE.Vector3(box.min.x, box.min.y, box.max.z),
+            new THREE.Vector3(box.min.x, box.max.y, box.max.z),
+            new THREE.Vector3(box.max.x, box.max.y, box.max.z),
+            new THREE.Vector3(box.max.x, box.max.y, box.min.z),
+            new THREE.Vector3(box.max.x, box.min.y, box.max.z),
+            new THREE.Vector3(box.max.x, box.min.y, box.min.z),
+          ]
+          // Transform the center and each corner to camera space
+          center.applyMatrix4(camera.matrixWorldInverse)
+          for (const v of vertices) {
+            v.applyMatrix4(camera.matrixWorldInverse)
+            maxHeight = Math.max(maxHeight, Math.abs(v.y - center.y))
+            maxWidth = Math.max(maxWidth, Math.abs(v.x - center.x))
+          }
+          maxHeight *= 2
+          maxWidth *= 2
+          const zoomForHeight = (camera.top - camera.bottom) / maxHeight
+          const zoomForWidth = (camera.right - camera.left) / maxWidth
+          goal.zoom = Math.min(zoomForHeight, zoomForWidth) / margin
+          if (!damping) {
+            camera.zoom = goal.zoom
+            camera.updateProjectionMatrix()
+          }
+        }
+
+        if (damping) {
+          current.animating = true
+        } else {
+          camera.position.copy(goal.camera)
+          camera.lookAt(goal.focus)
+          if (controls) {
+            controls.target.copy(goal.focus)
+            controls.update()
+          }
+        }
+        if (onFitRef.current) onFitRef.current(this.getSize())
+        invalidate()
+        return this
+      },
+    }
+  }, [box, camera, controls, margin, damping, invalidate])
+
+  React.useLayoutEffect(() => {
+    if (controls) {
+      // Try to prevent drag hijacking
+      const callback = () => (current.animating = false)
+      controls.addEventListener('start', callback)
+      return () => controls.removeEventListener('start', callback)
+    }
+  }, [controls])
+
+  // Scale pointer on window resize
+  const count = React.useRef(0)
+  React.useLayoutEffect(() => {
+    if (observe || count.current++ === 0) {
+      api.refresh()
+      if (fit) api.fit()
+      if (clip) api.clip()
+    }
+  }, [size, clip, fit, observe, camera, controls])
+
+  useFrame((state, delta) => {
+    if (current.animating) {
+      damp(current.focus, goal.focus, damping, delta)
+      damp(current.camera, goal.camera, damping, delta)
+      current.zoom = THREE.MathUtils.damp(current.zoom, goal.zoom, damping, delta)
+      camera.position.copy(current.camera)
+
+      if (isOrthographic(camera)) {
+        camera.zoom = current.zoom
+        camera.updateProjectionMatrix()
+      }
+
+      if (!controls) {
+        camera.lookAt(current.focus)
+      } else {
+        controls.target.copy(current.focus)
+        controls.update()
+      }
+
+      invalidate()
+      if (isOrthographic(camera) && !(Math.abs(current.zoom - goal.zoom) < eps)) return
+      if (!isOrthographic(camera) && !equals(current.camera, goal.camera)) return
+      if (controls && !equals(current.focus, goal.focus)) return
+      current.animating = false
+    }
+  })
+
+
+  return (
+    <group ref={ref}>
+      <context.Provider value={api}>{children}</context.Provider>
+    </group>
+  )
+}
+
+export function useBounds() {
+  return React.useContext(context)
+}

--- a/src/layers/common/Universe.tsx
+++ b/src/layers/common/Universe.tsx
@@ -3,6 +3,7 @@ import {
   MapControls,
   OrbitControls,
   PerspectiveCamera,
+  useHelper,
 } from "@react-three/drei";
 import React, { useEffect } from "react";
 import { FormantColors } from "../utils/FormantColors";
@@ -17,14 +18,16 @@ import { VRButton, XR, Controllers, Hands } from "@react-three/xr";
 import { BlendFunction } from "postprocessing";
 import Sidebar from "../../components/Sidebar";
 import { UIDataContext, useUI } from "./UIDataContext";
-import { MathUtils, Scene, Vector3 } from "three";
+import { Euler, MathUtils, Scene, Vector3 } from "three";
 import ZoomControls from "../../components/ZoomControls";
 import { LayerType } from "./LayerTypes";
+import { ControlsContext } from "./ControlsContext";
+import { Bounds } from "./CustomBounds";
 
 const query = new URLSearchParams(window.location.search);
 const shouldUseVR = query.get("vr") === "true";
 const fancy = query.get("fancy") === "true";
-const DEFAULT_CAMERA_POSITION = new Vector3(0, 0, 40);
+const DEFAULT_CAMERA_POSITION = new Vector3(0, 0, 20);
 
 type IUniverseProps = {
   children?: React.ReactNode;
@@ -103,6 +106,12 @@ export function Universe(props: IUniverseProps) {
     },
     [scene, mapControlsRef]
   );
+
+  const centerOnDevice = React.useCallback(() => {
+    const deviceMarker = layers.find((l) => l.type === LayerType.TRACKABLE);
+    if (deviceMarker)
+      lookAtTargetId(deviceMarker.id);
+  }, [layers, lookAtTargetId]);
 
   const recenter = React.useCallback(() => {
     const m = mapControlsRef.current;
@@ -215,7 +224,7 @@ export function Universe(props: IUniverseProps) {
       const deviceMarker = layers.find((l) => l.type === LayerType.TRACKABLE);
       if (deviceMarker) {
         setTimeout(() => {
-          lookAtTargetId(deviceMarker.id);
+          //lookAtTargetId(deviceMarker.id);
         }, 4000);
         setHasCentered(true);
       }
@@ -247,58 +256,65 @@ export function Universe(props: IUniverseProps) {
         >
           <XR>
             <color attach="background" args={[FormantColors.flagship]} />
-            <MapControls
-              enableDamping={false}
-              ref={mapControlsRef}
-              minDistance={1}
-              maxPolarAngle={Math.PI / 2 - 0.1}
-            />
-            <PerspectiveCamera
-              makeDefault
-              position={[0, 0, 300]}
-              up={[0, 0, 1]}
-              far={5000}
-            />
-            <group>{props.children}</group>
-            {fancy && (
-              <EffectComposer>
-                {/* <DepthOfField
+            <ControlsContext.Provider value={{ mapControlsRef }}>
+              <PerspectiveCamera
+                makeDefault
+                position={[0, 0, 300]}
+                up={[0, 0, 1]}
+                far={5000}
+
+              />
+              <MapControls
+                makeDefault
+                enableDamping={false}
+                ref={mapControlsRef}
+                minDistance={1}
+                maxPolarAngle={Math.PI / 2 - 0.1}
+                attach={"controls"}
+              />
+              <Bounds clip fit observe margin={1.5} damping={6}>
+                <group>{props.children}</group>
+              </Bounds>
+              {fancy && (
+                <EffectComposer>
+                  {/* <DepthOfField
                   focusDistance={0}
                   focalLength={0.02}
                   bokehScale={2}
                   height={480}
                 /> */}
-                <Bloom mipmapBlur intensity={1.0} luminanceThreshold={0.5} />
-                <Noise opacity={0.02} />
-                <Vignette
-                  offset={0.3}
-                  darkness={0.9}
-                  blendFunction={BlendFunction.NORMAL}
-                />
-              </EffectComposer>
-            )}
-            {vr && (
-              <>
-                <Controllers rayMaterial={{ color: "red" }} />
-                <Hands />
-                <mesh>
-                  <boxGeometry />
-                  <meshBasicMaterial color="blue" />
-                </mesh>
-              </>
-            )}
+                  <Bloom mipmapBlur intensity={1.0} luminanceThreshold={0.5} />
+                  <Noise opacity={0.02} />
+                  <Vignette
+                    offset={0.3}
+                    darkness={0.9}
+                    blendFunction={BlendFunction.NORMAL}
+                  />
+                </EffectComposer>
+              )}
+              {vr && (
+                <>
+                  <Controllers rayMaterial={{ color: "red" }} />
+                  <Hands />
+                  <mesh>
+                    <boxGeometry />
+                    <meshBasicMaterial color="blue" />
+                  </mesh>
+                </>
+              )}
+            </ControlsContext.Provider>
           </XR>
         </Canvas>
         <Sidebar lookAtTargetId={lookAtTargetId} />
         <ZoomControls
           zoomIn={zoomIn}
           zoomOut={zoomOut}
-          recenter={recenter}
+          recenter={centerOnDevice}
           stopZoom={stopZoom}
           isEditing={isEditing}
           toggleEditMode={toggleEditMode}
         />
-      </UIDataContext.Provider>
+      </UIDataContext.Provider >
     </>
   );
 }

--- a/src/layers/common/Universe.tsx
+++ b/src/layers/common/Universe.tsx
@@ -1,11 +1,9 @@
 import { Canvas, ThreeElements, useFrame, useThree } from "@react-three/fiber";
 import {
   MapControls,
-  OrbitControls,
   PerspectiveCamera,
-  useHelper,
 } from "@react-three/drei";
-import React, { useEffect } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { FormantColors } from "../utils/FormantColors";
 import {
   EffectComposer,
@@ -36,6 +34,15 @@ type IUniverseProps = {
 
 let zooming = false;
 let autoCameraMoving = false;
+
+const WaitForControls = ({ children }: { children: ReactNode }) => {
+  const { controls } = useThree();
+  if (controls) {
+    return <>{children}</>;
+  }
+  return null;
+};
+
 export function Universe(props: IUniverseProps) {
   const [scene, setScene] = React.useState<Scene | null>(null!);
   const [hasCentered, setHasCentered] = React.useState(false);
@@ -231,6 +238,7 @@ export function Universe(props: IUniverseProps) {
     }
   }, [layers, scene]);
 
+
   return (
     <>
       <UIDataContext.Provider
@@ -272,9 +280,11 @@ export function Universe(props: IUniverseProps) {
                 maxPolarAngle={Math.PI / 2 - 0.1}
                 attach={"controls"}
               />
-              <Bounds clip observe margin={1.5} damping={6}>
-                <group>{props.children}</group>
-              </Bounds>
+              <WaitForControls>
+                <Bounds clip observe margin={1.5} damping={6}>
+                  <group>{props.children}</group>
+                </Bounds>
+              </WaitForControls>
               {fancy && (
                 <EffectComposer>
                   {/* <DepthOfField

--- a/src/layers/common/Universe.tsx
+++ b/src/layers/common/Universe.tsx
@@ -272,7 +272,7 @@ export function Universe(props: IUniverseProps) {
                 maxPolarAngle={Math.PI / 2 - 0.1}
                 attach={"controls"}
               />
-              <Bounds clip fit observe margin={1.5} damping={6}>
+              <Bounds clip observe margin={1.5} damping={6}>
                 <group>{props.children}</group>
               </Bounds>
               {fancy && (

--- a/src/layers/objects/Axis.tsx
+++ b/src/layers/objects/Axis.tsx
@@ -17,7 +17,7 @@ export function Axis() {
         lineWidth={1}
       />
       <Line
-        points={[0, 0, 0, 0, 0, size]}
+        points={[0, 0, 0, 0, 0, 20]}
         color={FormantColors.blue}
         lineWidth={1}
       />

--- a/src/layers/objects/Axis.tsx
+++ b/src/layers/objects/Axis.tsx
@@ -1,20 +1,26 @@
+import { Line } from "@react-three/drei";
 import { FormantColors } from "../utils/FormantColors";
 
 export function Axis() {
+  const size = 1000;
+
   return (
     <>
-      <mesh position={[1, 0, 0]}>
-        <boxGeometry args={[1000, 0.01, 0.01]} />
-        <meshStandardMaterial color={FormantColors.red} />
-      </mesh>
-      <mesh position={[0, 1, 0]}>
-        <boxGeometry args={[0.01, 1000, 0.01]} />
-        <meshStandardMaterial color={FormantColors.green} />
-      </mesh>
-      <mesh position={[0, 0, 1]}>
-        <boxGeometry args={[0.01, 0.01, 20]} />
-        <meshStandardMaterial color={FormantColors.blue} />
-      </mesh>
+      <Line
+        points={[0, 0, 0, size, 0, 0]}
+        color={FormantColors.red}
+        lineWidth={1}
+      />
+      <Line
+        points={[0, 0, 0, 0, size, 0]}
+        color={FormantColors.green}
+        lineWidth={1}
+      />
+      <Line
+        points={[0, 0, 0, 0, 0, size]}
+        color={FormantColors.blue}
+        lineWidth={1}
+      />
     </>
   );
 }


### PR DESCRIPTION
- Change GroundPlane from boxes to lines representing the axis
- Add custom Bounds component that ignores the axis size when computing size
- Recenter button now focus on device