### PR TITLE
dont ignore rtcStream if stream is also present

### DIFF
--- a/src/layers/DataVisualizationLayer.tsx
+++ b/src/layers/DataVisualizationLayer.tsx
@@ -175,14 +175,15 @@ export function DataVisualizationLayer(props: IDataVisualizationLayerProps) {
         setPositionUnsubscriber(() => unsubscribe);
       } else if (p.type === "odometry") {
         let d;
-        if (p.stream) {
+        if (p.rtcStream) {
+          d = DataSourceBuilder.realtime(p.rtcStream, "json");
+
+        } else if (p.stream) {
           d = DataSourceBuilder.telemetry(
             p.stream,
             undefined,
             p.useLatestDataPoint || false
           );
-        } else if (p.rtcStream) {
-          d = DataSourceBuilder.realtime(p.rtcStream, "json");
         } else {
           throw new Error("invalid odometry positioning stream type");
         }


### PR DESCRIPTION
Still working on testing realtime, however this cant be ignored. You can't enter a realtime stream without a stream present, and if a stream is present it will use that instead of realtime.