### PR TITLE
Map Flickering and drifting issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@dimforge/rapier3d": "^0.11.1",
-    "@formant/data-sdk": "^1.33.1",
+    "@formant/data-sdk": "1.41.0",
     "@formant/ui-sdk": "0.0.45",
     "@formant/universe-core": "0.0.17",
     "@react-three/drei": "^9.92.7",

--- a/src/layers/OccupancyGridLayer.tsx
+++ b/src/layers/OccupancyGridLayer.tsx
@@ -34,8 +34,8 @@ interface IPointOccupancyGridProps extends IUniverseLayerProps {
   dataSource?: UniverseTelemetrySource;
 }
 
-const mapColor = defined(new Color(FormantColors.mapColor));
-const occupiedColor = defined(new Color(FormantColors.occupiedColor));
+const mapColor = defined(new Color(FormantColors.steel02));
+const occupiedColor = defined(new Color(FormantColors.steel03));
 const createGridMaterial = () => {
   return new MeshBasicMaterial({
     transparent: true,
@@ -47,6 +47,7 @@ const createGridMaterial = () => {
 const createMesh = (material: MeshBasicMaterial) => {
   const mesh = new Mesh(new PlaneGeometry(1, 1), material);
   mesh.visible = false;
+  mesh.up = new Vector3(0, 0, 1);
   return mesh;
 };
 
@@ -81,48 +82,50 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
           resolution,
           data,
           worldToLocal,
-          canvas,
+          alpha
         } = gridData as IUniverseGridMap;
-        if (isReady) return;
         const mesh = obj.current;
         mesh.matrixAutoUpdate = false;
+        const _origin = {
+          translation: {
+            x: origin.translation.x + (width * resolution) / 2,
+            y: origin.translation.y + (height * resolution) / 2,
+            z: origin.translation.z - 0.01,
+          },
+          rotation: {
+            x: origin.rotation.x,
+            y: origin.rotation.y,
+            z: origin.rotation.z,
+            w: origin.rotation.w,
+          }
+        }
 
-        origin.translation.x += (width * resolution) / 2;
-        origin.translation.y += (height * resolution) / 2;
-        origin.translation.z -= 0.01;
-
-        const newMatrix = transformMatrix(origin).multiply(
+        const newMatrix = transformMatrix(_origin).multiply(
           new Matrix4().makeScale(width * resolution, height * resolution, 1)
         );
         if (worldToLocal) newMatrix.multiply(transformMatrix(worldToLocal));
 
-        mesh.matrix.copy(newMatrix);
+
+
 
         const size = width * height;
-        const textureData = new Uint8Array(4 * size);
+        const textureData = new Uint8Array(4 * size); const color = new Color();
 
-        const pixelDataFromCanvas = (
-          canvas && canvas.getContext("2d")
-        )?.getImageData(0, 0, width, height).data;
 
-        for (let i = 0; i < size; i++) {
+        for (let i = 0; i < data.length; i++) {
           const stride = i * 4;
-          const grayValue = data[i] / 255.0; // Normalize data value to the range [0, 1]
+          const grayValue = (data[i] / 255.0); // Normalize data value to the range [0, 1]
           const occupancy = smoothstep(grayValue, 0.01, 0.5); // Map the grayscale value to the range [0.01, 0.5]
 
           // Map the grayscale value to the formant colors
-          const color = new Color();
+
           color.lerpColors(occupiedColor, mapColor, occupancy);
 
           // Set the color channels in the textureData
           textureData[stride] = Math.round(color.r * 255); // Red channel
           textureData[stride + 1] = Math.round(color.g * 255); // Green channel
           textureData[stride + 2] = Math.round(color.b * 255); // Blue channel
-          textureData[stride + 3] = 255; // Alpha channel (fully opaque)
-
-          if (pixelDataFromCanvas) {
-            textureData[stride + 3] = pixelDataFromCanvas[stride + 3];
-          }
+          textureData[stride + 3] = alpha[i]; // Alpha channel (fully opaque)
         }
 
         // Create a new DataTexture and set its properties
@@ -132,12 +135,14 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
 
         // Update the material with the new DataTexture and set other properties
         gridMat.map = texture;
-        gridMat.needsUpdate = true;
-        gridMat.opacity = 0.6;
+        gridMat.opacity = 0.9;
         gridMat.depthTest = true;
         gridMat.color = new Color(0xffffff);
+        gridMat.needsUpdate = true;
 
-        mesh.up = new Vector3(0, 0, 1);
+        mesh.matrix.copy(newMatrix);
+        mesh.updateMatrixWorld(true);
+
 
         if (!mesh.visible && size) {
           setIsReady(true);


### PR DESCRIPTION
Issues were caused by overwriting the origin in the received object from data-sdk. A feedback loop would be formed and the map would continuosly drift away.
Removed unnecessary processing of the canvas, using the new alpha array. 
Updated the style to match localization module colors.

**Update to the new version of data-sdk before merging (https://github.com/FormantIO/toolkit/pull/167) **