### PR TITLE
Dev-8495

### DIFF
--- a/src/Demo.tsx
+++ b/src/Demo.tsx
@@ -49,7 +49,7 @@ export function Demo() {
         }}
       >
         <group>
-          {/* <pointLight
+          <pointLight
             position={[1000, 1000, 1000]}
             color={"#18d2ff"}
             intensity={0.3 * 2.8}
@@ -62,15 +62,11 @@ export function Demo() {
             intensity={0.7 * 2.8}
             decay={0}
             distance={0}
-          /> */}
+          />
           <hemisphereLight
             intensity={0.2 * 2.8}
             color={"#f8f9fc"}
             groundColor={"#282f45"}
-          />
-          <ambientLight
-            intensity={3}
-            color={"#f8f9fc"}
           />
         </group>
 

--- a/src/layers/MarkerLayer.tsx
+++ b/src/layers/MarkerLayer.tsx
@@ -30,8 +30,9 @@ export function MarkerLayer(props: IUniverseLayerProps) {
     if (!circle || !arrow) return;
 
     const scaleFactor = 35;
-    const distanceFromCamera = circle.position.distanceTo(camera.position);
-    const scale = distanceFromCamera / scaleFactor;
+    const circlePosition = circle.getWorldPosition(new THREE.Vector3());
+    const distanceFromCamera = camera.position.distanceTo(circlePosition);
+    const scale = Math.max(distanceFromCamera, 3.0) / scaleFactor;
     circle.scale.setScalar(scale);
     arrow.scale.setScalar(scale);
 
@@ -45,19 +46,18 @@ export function MarkerLayer(props: IUniverseLayerProps) {
       type={LayerType.TRACKABLE}
       iconUrl="icons/3d_object.svg"
     >
-      <group renderOrder={2}>
-        <mesh ref={arrowRef} name="arrow" rotation={[0, 0, -Math.PI / 2]} up={new THREE.Vector3(0, 0, 1)}>
+      <group >
+        <mesh ref={arrowRef} name="arrow" rotation={[0, 0, -Math.PI / 2]} up={new THREE.Vector3(0, 0, 1)} renderOrder={9}>
           <shapeGeometry args={[arrowShape]} />
           <meshStandardMaterial
             color="white"
             emissive="white"
             emissiveIntensity={2}
             toneMapped={false}
-            depthTest={false}
-            depthWrite={false}
+            depthTest={true}
           />
         </mesh>
-        <mesh name="circle" ref={circleRef}>
+        <mesh name="circle" ref={circleRef} renderOrder={8}>
           <circleGeometry args={[0.8, 20]} />
           <markerMaterial
             transparent={true}

--- a/src/layers/PointCloudLayer.tsx
+++ b/src/layers/PointCloudLayer.tsx
@@ -83,7 +83,6 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
         float cameraDistance = length(projectedPosition.xyz);
         float q = pow(pointScale, 3.0) / (cameraDistance * density);
         float redShift = (radius - cameraDistance) / radius / 2.0;
-        //float q = pow(pointScale, 3.0) / (distance(position, cameraPosition) * density);
         float intensity = ((color.r * 65025.0) + (color.g * 255.0) + color.b) / 65025.0;
         float minLuminocity = 0.5;
         float maxLuminocity = 2.0;

--- a/src/layers/PointCloudLayer.tsx
+++ b/src/layers/PointCloudLayer.tsx
@@ -14,6 +14,7 @@ import {
   Points,
   ShaderMaterial,
   TextureLoader,
+  Vector3,
 } from "three";
 import { Color } from "./utils/Color";
 import { useControlsContext } from "./common/ControlsContext";
@@ -78,10 +79,11 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
     }
     
     void main() {
-        
-        float cameraDistance = distance(position, cameraPosition);
+        vec4 projectedPosition = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        float cameraDistance = length(projectedPosition.xyz);
+        float q = pow(pointScale, 3.0) / (cameraDistance * density);
         float redShift = (radius - cameraDistance) / radius / 2.0;
-        float q = pow(pointScale, 3.0) / (distance(position, cameraPosition) * density);
+        //float q = pow(pointScale, 3.0) / (distance(position, cameraPosition) * density);
         float intensity = ((color.r * 65025.0) + (color.g * 255.0) + color.b) / 65025.0;
         float minLuminocity = 0.5;
         float maxLuminocity = 2.0;
@@ -142,6 +144,7 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
 
     const geometry = new BufferGeometry();
     const points = new Points(geometry, pointMat);
+    points.up = new Vector3(0, 0, 1);
     points.frustumCulled = false;
     objRef.current = points;
 
@@ -174,6 +177,7 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
             : identityTransform;
 
           if (positions && positions.length > 0) {
+
             geometry.setAttribute(
               "position",
               new BufferAttribute(new Float32Array(positions), 3)
@@ -214,6 +218,9 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
             const clampedRadius = radius > 50 ? 50 : radius;
             const volume = (4 / 3) * Math.PI * Math.pow(clampedRadius, 3);
             const density = Math.pow(numPoints / (volume || 1), 0.3333);
+            points.matrixAutoUpdate = false;
+            points.matrix.copy(transformMatrix(worldToLocal));
+
 
             pointMat.uniforms.intensityMin.value = intensityMin;
             pointMat.uniforms.intensityMax.value = intensityMax;
@@ -221,8 +228,7 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
             pointMat.uniforms.density.value = density;
             pointMat.needsUpdate = true;
 
-            points.matrixAutoUpdate = false;
-            points.matrix.copy(transformMatrix(worldToLocal));
+
             objRef.current = points;
           }
         }

--- a/src/layers/common/ExampleUniverseData.ts
+++ b/src/layers/common/ExampleUniverseData.ts
@@ -192,7 +192,7 @@ export class ExampleUniverseData implements IUniverseData {
     callback: (data: IUniverseOdometry) => void
   ): CloseSubscription {
     let time = 0;
-    const radius = 3; // Radius of the circular path
+    const radius = 1; // Radius of the circular path
     const frequency = 0.1; // Controls the speed of movement
 
     const interval = setInterval(() => {


### PR DESCRIPTION
There are two issues: The position indicator would get large when zooming in and way smaller when viewed from critical angles. This is because it’s calculating the distance to the camera as if it is stuck to 0,0,0. So the closer you get to the origin, the smaller it becomes.
Fixed by using the .getWorldPosition function, as position wouldn't reflect the actual position of the circle.

And the pointcloud being huge at very specific angles. In the shader we’re forgetting to apply the projection transformations before calculating the distance to the camera.

First we're applying the matrix before updating the shadermaterial. 
And then, inside the shader material, we use the projected position instead of the raw position to calculate the distance to camera.