### PR TITLE
Dev-8542

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@dimforge/rapier3d": "^0.11.1",
-    "@formant/data-sdk": "1.44.0",
+    "@formant/data-sdk": "1.44.1",
     "@formant/ui-sdk": "0.0.45",
     "@formant/universe-core": "0.0.17",
     "@react-three/drei": "^9.92.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@dimforge/rapier3d": "^0.11.1",
-    "@formant/data-sdk": "1.42.0",
+    "@formant/data-sdk": "1.44.0",
     "@formant/ui-sdk": "0.0.45",
     "@formant/universe-core": "0.0.17",
     "@react-three/drei": "^9.92.7",

--- a/src/buildScene.tsx
+++ b/src/buildScene.tsx
@@ -158,7 +158,6 @@ export function buildScene(
         const stream = deviceConfig?.telemetry?.streams?.find(
           s => s.name === layer.telemetryStreamName
         ) as { configuration: { type: string } } | undefined; // seems like the type might be missing
-        console.log(stream);
 
         const streamType = stream
           ? stream.configuration.type === "ros-localization"

--- a/src/layers/OccupancyGridLayer.tsx
+++ b/src/layers/OccupancyGridLayer.tsx
@@ -16,34 +16,83 @@ import {
   defined,
 } from "@formant/data-sdk";
 
+
 import {
+  ClampToEdgeWrapping,
   Color,
+  CustomBlending,
   DataTexture,
+  DoubleSide,
+  LinearFilter,
   Matrix4,
   Mesh,
-  MeshBasicMaterial,
+  NearestFilter,
   PlaneGeometry,
   RGBAFormat,
+  ShaderMaterial,
+  Texture,
+  TextureLoader,
   Vector3,
 } from "three";
 import { FormantColors } from "./utils/FormantColors";
 import { useBounds } from "./common/CustomBounds";
-import { smoothstep } from "three/src/math/MathUtils";
 
 interface IPointOccupancyGridProps extends IUniverseLayerProps {
   dataSource?: UniverseTelemetrySource;
 }
 
-const mapColor = defined(new Color(FormantColors.steel02));
+const mappedColor = defined(new Color(FormantColors.steel02));
 const occupiedColor = defined(new Color(FormantColors.steel03));
+
+const glColor = (c: Color) => {
+  // I have NO IDEA why c.r, c.g, c.b are completely wrong, so im using hex
+  const hex = c.getHex();
+  const r = (hex >> 16) & 255;
+  const g = (hex >> 8) & 255;
+  const b = hex & 255;
+
+  return `vec3(${r.toFixed(1)}/255.0, ${g.toFixed(1)}/255.0, ${b.toFixed(1)}/255.0)`;
+}
+
+const vertexShader = `
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+const fragmentShader = `
+uniform sampler2D mapTexture;
+varying vec2 vUv;
+
+void main() {
+   vec4 map = texture2D( mapTexture, vUv.xy );
+    vec3 mappedColor = ${glColor(mappedColor)};
+    //vec3 mappedColor = vec3(0.0, 0.0, 1.0);
+    vec3 occupiedColor = ${glColor(occupiedColor)};
+    float occupancy = smoothstep(0.5, 0.01, map.r);
+    vec3 color = mix(mappedColor, occupiedColor, smoothstep(0.0, 1.0, occupancy));
+    gl_FragColor = vec4(color, map.a);
+}
+`;
+
+
 const createGridMaterial = () => {
-  return new MeshBasicMaterial({
-    transparent: true,
-    color: 0xffffff,
+  return new ShaderMaterial({
+    blending: CustomBlending,
+    depthTest: true,
+    depthWrite: true,
+    uniforms: {
+      mapTexture: { value: new Texture() },
+    },
+    vertexShader,
+    fragmentShader,
+    side: DoubleSide,
   });
 };
 
-const createMesh = (material: MeshBasicMaterial) => {
+const createMesh = (material: ShaderMaterial) => {
   const mesh = new Mesh(new PlaneGeometry(1, 1), material);
   mesh.visible = false;
   mesh.up = new Vector3(0, 0, 1);
@@ -53,6 +102,7 @@ const createMesh = (material: MeshBasicMaterial) => {
 export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
   const { dataSource } = props;
   const [isReady, setIsReady] = useState(false);
+  const [url, setUrl] = useState<string | undefined>(undefined);
   const [universeData, liveUniverseData] = useContext(UniverseDataContext);
   const layerData = useContext(LayerContext);
   const bounds = useBounds();
@@ -60,6 +110,29 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
   const gridMat = useRef(createGridMaterial()).current;
   const mesh = useRef(createMesh(gridMat)).current;
   const obj = useRef(mesh);
+
+  useEffect(() => {
+    if (url) {
+      const loader = new TextureLoader();
+      loader.load(url, (texture) => {
+        texture.generateMipmaps = false;
+        texture.wrapS = ClampToEdgeWrapping;
+        texture.wrapT = ClampToEdgeWrapping;
+        texture.minFilter = LinearFilter;
+        texture.magFilter = NearestFilter;
+
+
+        gridMat.uniforms.mapTexture.value = texture;
+
+        gridMat.needsUpdate = true;
+
+        if (!mesh.visible) {
+          setIsReady(true);
+          obj.current.visible = true;
+        }
+      })
+    }
+  }, [url]);
 
   useEffect(() => {
     if (!layerData || !dataSource) return;
@@ -81,10 +154,13 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
           resolution,
           data,
           worldToLocal,
-          alpha
+          alpha,
+          url: _url,
         } = gridData as IUniverseGridMap;
+
         const mesh = obj.current;
         mesh.matrixAutoUpdate = false;
+
         const _origin = {
           translation: {
             x: origin.translation.x + (width * resolution) / 2,
@@ -104,27 +180,29 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
         );
         if (worldToLocal) newMatrix.multiply(transformMatrix(worldToLocal));
 
+        mesh.matrix.copy(newMatrix);
+        mesh.updateMatrixWorld(true);
 
 
+        if (_url) {
+          // url is a primitive string, so setting the same value will not trigger a re-render, nor will it trigger the useEffect
+          setUrl(_url);
+          return;
+        }
+        if (!data) {
+          return;
+        }
 
+        // if no url, fallback to the old method of creating the texture
+        // this is slow and should be avoided
         const size = width * height;
-        const textureData = new Uint8Array(4 * size); const color = new Color();
-
-
-        for (let i = 0; i < data.length; i++) {
-          const stride = i * 4;
-          const grayValue = (data[i] / 255.0); // Normalize data value to the range [0, 1]
-          const occupancy = smoothstep(grayValue, 0.01, 0.5); // Map the grayscale value to the range [0.01, 0.5]
-
-          // Map the grayscale value to the formant colors
-
-          color.lerpColors(occupiedColor, mapColor, occupancy);
-
-          // Set the color channels in the textureData
-          textureData[stride] = Math.round(color.r * 255); // Red channel
-          textureData[stride + 1] = Math.round(color.g * 255); // Green channel
-          textureData[stride + 2] = Math.round(color.b * 255); // Blue channel
-          textureData[stride + 3] = alpha ? alpha[i] : 255; // Alpha channel (fully opaque)
+        const textureData = new Uint8Array(4 * size);
+        for (let i = 0; i < size; i++) {
+          const value = data[i] * 255;
+          textureData[i * 4] = value;
+          textureData[i * 4 + 1] = value;
+          textureData[i * 4 + 2] = value;
+          textureData[i * 4 + 3] = alpha ? alpha[i] * 255 : 255;
         }
 
         // Create a new DataTexture and set its properties
@@ -132,11 +210,20 @@ export const OccupancyGridLayer = (props: IPointOccupancyGridProps) => {
         texture.flipY = true;
         texture.needsUpdate = true;
 
+        //convert dataTexture to texture
+        texture.generateMipmaps = false;
+        texture.wrapS = ClampToEdgeWrapping;
+        texture.wrapT = ClampToEdgeWrapping;
+        texture.minFilter = LinearFilter;
+        texture.magFilter = NearestFilter;
+
+        const actualTexture = texture as Texture;
+
+
         // Update the material with the new DataTexture and set other properties
-        gridMat.map = texture;
+        gridMat.uniforms.mapTexture.value = actualTexture;
         gridMat.opacity = 0.9;
         gridMat.depthTest = true;
-        gridMat.color = new Color(0xffffff);
         gridMat.needsUpdate = true;
 
         mesh.matrix.copy(newMatrix);

--- a/src/layers/PointCloudLayer.tsx
+++ b/src/layers/PointCloudLayer.tsx
@@ -28,7 +28,7 @@ interface IPointCloudProps extends IUniverseLayerProps {
 }
 
 export const PointCloudLayer = (props: IPointCloudProps) => {
-  const { dataSource, decayTime, useColors: fullColor } = props;
+  const { dataSource, useColors: fullColor } = props;
   const [universeData, liveUniverseData] = useContext(UniverseDataContext);
   const layerData = useContext(LayerContext);
   const {
@@ -81,7 +81,7 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
     void main() {
         vec4 projectedPosition = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
         float cameraDistance = length(projectedPosition.xyz);
-        float q = pow(pointScale, 3.0) / (cameraDistance * density);
+        float q = pow(pointScale,3.0) / (cameraDistance * density);
         float redShift = (radius - cameraDistance) / radius / 2.0;
         float intensity = ((color.r * 65025.0) + (color.g * 255.0) + color.b) / 65025.0;
         float minLuminocity = 0.5;
@@ -125,6 +125,7 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
       blendEquation: MaxEquation,
       blending: CustomBlending,
       depthTest: true,
+      depthWrite: false,
       vertexShader,
       fragmentShader,
       uniforms: {
@@ -159,14 +160,8 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
 
           points.visible = true;
 
-          if (timer) clearTimeout(timer);
-
-          timer = window.setTimeout(() => {
-            points.visible = false;
-          }, decayTime * 1000);
-
           const pc = data as IUniversePointCloud;
-          const { header, positions, colors } = defined(pc.pcd);
+          const { positions, colors } = defined(pc.pcd);
           const identityTransform: ITransform = {
             translation: { x: 0, y: 0, z: 0 },
             rotation: { x: 0, y: 0, z: 0, w: 1 },
@@ -237,7 +232,7 @@ export const PointCloudLayer = (props: IPointCloudProps) => {
         unsubscribe();
       };
     }
-  }, [layerData, universeData]);
+  }, [layerData, universeData, liveUniverseData, dataSource]);
 
   return (
     <DataVisualizationLayer {...props} iconUrl="icons/3d_object.svg">


### PR DESCRIPTION
- use a ref to universeData instead of state, to keep it between renders
- Remove the need to recreate the occupancy map texture every render, now it receives a url and checks against the current url.
- Use a shader to determine the color instead of javascript, this was a bottleneck for very large maps
- Fix pointcloud transparency issue by enabling depthwrite

(dont merge without the latest data-sdk version)