### PR TITLE
Refreshing both map and geometry layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@dimforge/rapier3d": "^0.11.1",
-    "@formant/data-sdk": "1.47.0",
+    "@formant/data-sdk": "1.48.0",
     "@formant/ui-sdk": "0.0.45",
     "@formant/universe-core": "0.0.17",
     "@react-three/drei": "^9.107.0",

--- a/src/layers/MapLayer.tsx
+++ b/src/layers/MapLayer.tsx
@@ -148,6 +148,7 @@ export function MapLayer(props: IMapLayer) {
           materialRef.current[i].map = texture;
           materialRef.current[i].color = new Color("#FFFFFF");
           materialRef.current[i].needsUpdate = true;
+          materialRef.current[i].depthWrite = false;
           return texture;
         })
       ).then(() => {
@@ -230,12 +231,13 @@ export function MapLayer(props: IMapLayer) {
 
   return (
     <DataVisualizationLayer {...props} iconUrl="icons/map.svg">
-      <group visible={highResLoaded} position={[0, 0, -0.01]}>{meshesArrayRef.current}</group>
-      <mesh ref={lowResMapRef} visible={!highResLoaded} position={[0, 0, -0.01]}>
+      <group visible={highResLoaded} position={[0, 0, -0.015]}>{meshesArrayRef.current}</group>
+      <mesh ref={lowResMapRef} visible={!highResLoaded} position={[0, 0, -0.015]}>
         <planeGeometry attach="geometry" args={[size, size]} />
         {lowMapTextures.length > 0 ? (
           <meshStandardMaterial
             map={lowMapTextures[lowMapTextures.length - 1]}
+            depthWrite={false}
           />
         ) : (
           /* @ts-ignore -- extend() extends JSX but keeps giving TS warning */

--- a/src/layers/MapLayer.tsx
+++ b/src/layers/MapLayer.tsx
@@ -2,7 +2,6 @@ import { defined, UniverseTelemetrySource } from "@formant/data-sdk";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import {
   Color,
-  Mesh,
   MeshBasicMaterial,
   NearestFilter,
   PlaneGeometry,
@@ -93,8 +92,6 @@ export function MapLayer(props: IMapLayer) {
       if (currentLocation === undefined) {
         return;
       }
-      unsubscribeToLocation && unsubscribeToLocation();
-
       if (bounds) {
         bounds.refresh().clip().fit();
       }
@@ -183,6 +180,7 @@ export function MapLayer(props: IMapLayer) {
                 ) {
                   return a;
                 }
+                setHighResLoaded(false);
                 return [loc.longitude, loc.latitude];
               });
             }

--- a/src/layers/common/Universe.tsx
+++ b/src/layers/common/Universe.tsx
@@ -201,6 +201,9 @@ export function Universe(props: IUniverseProps) {
             }}
             dpr={[1, 2]}
             flat
+            gl={{
+              logarithmicDepthBuffer: true,
+            }}
           >
             {debug && <Stats className="stats" />}
             <XR>
@@ -210,7 +213,7 @@ export function Universe(props: IUniverseProps) {
                   makeDefault
                   position={[0, 0, 10]}
                   up={[0, 0, 1]}
-                  far={5000}
+                  far={2500}
                   near={0.6}
                 />
                 <CameraControls

--- a/src/layers/objects/GeometryWorld.ts
+++ b/src/layers/objects/GeometryWorld.ts
@@ -130,6 +130,10 @@ function reifyColor(v: IColorRGBA) {
 export class GeometryWorld {
   geometry: Map<string, Map<number, Geometry>> = new Map();
 
+  deleteAll() {
+    this.geometry = new Map();
+  }
+
   processMarkers(markers: IMarker3DArray) {
     markers.markers.forEach((marker) => {
       let ns = this.geometry.get(marker.ns);

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,10 +512,10 @@
     "@formant/realtime-sdk" "^0.0.19"
     date-fns "^2.29.3"
 
-"@formant/data-sdk@1.47.0":
-  version "1.47.0"
-  resolved "https://registry.yarnpkg.com/@formant/data-sdk/-/data-sdk-1.47.0.tgz#c63a217c0cd623e7eb0f4d93c014f9ed8a1714cd"
-  integrity sha512-3sv2PLUKJZzrajcn/96wJ9CPrw7i3NP3clqRjbHJac7nDPEb2bf1PqQlK/XkKw+BkYG6R2zIp6y/HFa5d6iwcQ==
+"@formant/data-sdk@1.48.0":
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/@formant/data-sdk/-/data-sdk-1.48.0.tgz#2b3b3f8c14ead7c11c1703415918f12c2c2fb22d"
+  integrity sha512-KerIk6NQNiQfREQVPJg7MYg/uimULmzMItV+rIzPDB5ONa/kYX22Yf/64vQ653Me4bt4YrniuxFgS+hJirEAiA==
   dependencies:
     "@formant/ui-sdk-realtime-player-core" "^0.0.2"
     "@formant/ui-sdk-realtime-player-core-worker" "^0.0.4"


### PR DESCRIPTION
- Keep location subscription in map layer, allow it to reload all map images when location changes
- disable depthwrite from map and use logarithmicDepthBuffer to avoid z-fighting when zooming out
- check if geometry data is too old (12 hours) when a new one comes, deleting everything. This is very easily seen by changing the day in Ekobot's device, the old geometry data would persist on top of the new one.
